### PR TITLE
Update requirements.txt

### DIFF
--- a/gcastle/requirements.txt
+++ b/gcastle/requirements.txt
@@ -4,5 +4,5 @@ pandas>=0.22.0
 scipy>=1.7.3
 scikit-learn>=0.21.1
 matplotlib>=2.1.2
-networkx>=2.5
+networkx>=2.5,<3
 torch>=1.9


### PR DESCRIPTION
castle uses networkx's to_numpy_array, which got removed in 3.0.0 and onward. This change fixes the requirements.